### PR TITLE
Enhance user role management

### DIFF
--- a/src/features/admin/users/EditUser.tsx
+++ b/src/features/admin/users/EditUser.tsx
@@ -41,7 +41,11 @@ export function EditUser() {
     first_name: user.firstName,
     last_name: user.lastName,
     email: user.email,
-    enabled: user.enabled
+    enabled: user.enabled,
+    roles: [],
+    projects: [],
+    environments: [],
+    is_tenant_admin: false
   };
 
   return (

--- a/src/features/admin/users/components/FormFields.tsx
+++ b/src/features/admin/users/components/FormFields.tsx
@@ -105,3 +105,39 @@ export const ProjectsAndEnvironmentsFields = ({ form }: { form: any }) => {
     </div>
   )
 }
+
+export const TenantAdminField = ({ form }: { form: any }) => (
+  <div>
+    <FormField
+      control={form.control}
+      name="is_tenant_admin"
+      render={({ field }) => (
+        <FormItem className="flex flex-row items-center gap-2">
+          <FormLabel>Tenant Admin</FormLabel>
+          <FormControl>
+            <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+          </FormControl>
+          <span className="text-sm text-muted-foreground">{field.value ? 'Yes' : 'No'}</span>
+        </FormItem>
+      )}
+    />
+  </div>
+)
+
+export const RolesField = ({ form }: { form: any }) => {
+  const roleOptions = [
+    { label: 'Designer', value: 'designer' },
+    { label: 'Ops User', value: 'ops_user' },
+    { label: 'Admin', value: 'admin' },
+  ]
+
+  return (
+    <MultiSelect
+      form={form}
+      name="roles"
+      label="Roles"
+      placeholder="Select roles"
+      options={roleOptions}
+    />
+  )
+}

--- a/src/features/admin/users/components/MultiSelect.tsx
+++ b/src/features/admin/users/components/MultiSelect.tsx
@@ -1,6 +1,7 @@
 import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Badge } from "@/components/ui/badge"
 import { X } from "lucide-react"
@@ -79,36 +80,38 @@ export const MultiSelect = ({ form, name, label, placeholder, options }: MultiSe
           <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
             <Command>
               <CommandInput placeholder={`Search ${name}...`} />
-              <CommandList>
-                <CommandEmpty>No {name} found.</CommandEmpty>
-                <CommandGroup>
-                  {options.map((option) => (
-                    <CommandItem
-                      value={option.label}
-                      key={option.value}
-                      onSelect={() => {
-                        const currentValue = field.value || []
-                        const newValue = currentValue.includes(option.value)
-                          ? currentValue.filter((value: string) => value !== option.value)
-                          : [...currentValue, option.value]
-                        form.setValue(name, newValue)
-                      }}
-                    >
-                      <div
-                        className={cn(
-                          "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
-                          field.value?.includes(option.value)
-                            ? "bg-primary text-primary-foreground"
-                            : "opacity-50 [&_svg]:invisible"
-                        )}
+              <ScrollArea className="h-48">
+                <CommandList>
+                  <CommandEmpty>No {name} found.</CommandEmpty>
+                  <CommandGroup>
+                    {options.map((option) => (
+                      <CommandItem
+                        value={option.label}
+                        key={option.value}
+                        onSelect={() => {
+                          const currentValue = field.value || []
+                          const newValue = currentValue.includes(option.value)
+                            ? currentValue.filter((value: string) => value !== option.value)
+                            : [...currentValue, option.value]
+                          form.setValue(name, newValue)
+                        }}
                       >
-                        <X className="h-4 w-4" />
-                      </div>
-                      {option.label}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
+                        <div
+                          className={cn(
+                            "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
+                            field.value?.includes(option.value)
+                              ? "bg-primary text-primary-foreground"
+                              : "opacity-50 [&_svg]:invisible"
+                          )}
+                        >
+                          <X className="h-4 w-4" />
+                        </div>
+                        {option.label}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </ScrollArea>
             </Command>
           </PopoverContent>
         </Popover>

--- a/src/features/admin/users/components/UserForm.tsx
+++ b/src/features/admin/users/components/UserForm.tsx
@@ -11,6 +11,8 @@ import {
   EmailField,
   StatusField,
   ProjectsAndEnvironmentsFields,
+  TenantAdminField,
+  RolesField,
 } from "./FormFields";
 import type { UserMutationData } from "@/types/admin/user";
 
@@ -56,6 +58,8 @@ export function UserForm({
       enabled: true,
       projects: [],
       environments: [],
+      roles: [],
+      is_tenant_admin: false,
       ...initialData,
     },
   });
@@ -112,6 +116,8 @@ export function UserForm({
               {isEditMode && (
                 <>
                   <StatusField form={form} />
+                  <TenantAdminField form={form} />
+                  <RolesField form={form} />
                   <ProjectsAndEnvironmentsFields form={form} />
                 </>
               )}

--- a/src/features/admin/users/components/userFormSchema.ts
+++ b/src/features/admin/users/components/userFormSchema.ts
@@ -17,6 +17,8 @@ export const userEditSchema = z.object({
   enabled: z.boolean(),
   projects: z.array(z.string()).optional(),
   environments: z.array(z.string()).optional(),
+  roles: z.array(z.string()).optional(),
+  is_tenant_admin: z.boolean().optional(),
   username: z.string().optional(),
 });
 

--- a/src/types/admin/user.d.ts
+++ b/src/types/admin/user.d.ts
@@ -61,6 +61,10 @@ export type UserUpdateData = {
   username?: string;
   enabled?: boolean;
   emailVerified?: boolean;
+  roles?: string[];
+  projects?: string[];
+  environments?: string[];
+  is_tenant_admin?: boolean;
 };
 
 // Keep UserMutationData as a union for backward compatibility


### PR DESCRIPTION
## Summary
- support tenant admin and roles when editing a user
- allow setting roles using a multi-select with scrolling
- show new switch for tenant admin status
- expose the new fields in types and forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687684b654d883249ac4e5283fc680f8