### PR TITLE
Improve user role assignments

### DIFF
--- a/src/features/admin/users/EditUser.tsx
+++ b/src/features/admin/users/EditUser.tsx
@@ -42,9 +42,7 @@ export function EditUser() {
     last_name: user.lastName,
     email: user.email,
     enabled: user.enabled,
-    roles: [],
-    projects: [],
-    environments: [],
+    assignments: [],
     is_tenant_admin: false
   };
 

--- a/src/features/admin/users/components/FormFields.tsx
+++ b/src/features/admin/users/components/FormFields.tsx
@@ -4,6 +4,15 @@ import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { MultiSelect } from "./MultiSelect"
 import { getProjectOptions, getEnvironmentOptions } from "./userFormSchema"
+import { Button } from "@/components/ui/button"
+import { useFieldArray } from "react-hook-form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { useAppSelector } from "@/hooks/useRedux"
 
 export const RequiredFormLabel = ({ children }: { children: React.ReactNode }) => (
@@ -139,5 +148,90 @@ export const RolesField = ({ form }: { form: any }) => {
       placeholder="Select roles"
       options={roleOptions}
     />
+  )
+}
+
+export const RoleAssignmentsField = ({ form }: { form: any }) => {
+  const projects = useAppSelector((state) => state.users.projects)
+  const environments = useAppSelector((state) => state.users.environments)
+  const projectOptions = getProjectOptions(projects)
+  const environmentOptions = getEnvironmentOptions(environments)
+  const roleOptions = [
+    { label: 'Designer', value: 'designer' },
+    { label: 'Ops User', value: 'ops_user' },
+    { label: 'Admin', value: 'admin' },
+  ]
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'assignments'
+  })
+
+  return (
+    <div className="space-y-2">
+      <RequiredFormLabel>Role Assignments</RequiredFormLabel>
+      {fields.map((field: any, index: number) => (
+        <div key={field.id} className="grid grid-cols-4 gap-2 items-center">
+          <Select
+            value={form.watch(`assignments.${index}.project`) || ''}
+            onValueChange={(val) => form.setValue(`assignments.${index}.project`, val)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Project" />
+            </SelectTrigger>
+            <SelectContent>
+              {projectOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={form.watch(`assignments.${index}.environment`) || ''}
+            onValueChange={(val) => form.setValue(`assignments.${index}.environment`, val)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Environment" />
+            </SelectTrigger>
+            <SelectContent>
+              {environmentOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={form.watch(`assignments.${index}.role`) || ''}
+            onValueChange={(val) => form.setValue(`assignments.${index}.role`, val)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Role" />
+            </SelectTrigger>
+            <SelectContent>
+              {roleOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <button
+            type="button"
+            onClick={() => remove(index)}
+            className="text-destructive hover:underline text-sm"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => append({ project: '', environment: '', role: '' })}
+      >
+        Add Assignment
+      </Button>
+    </div>
   )
 }

--- a/src/features/admin/users/components/UserForm.tsx
+++ b/src/features/admin/users/components/UserForm.tsx
@@ -9,10 +9,8 @@ import { userFormSchema, userCreateSchema, type UserCreateValues, type UserFormV
 import {
   NameFields,
   EmailField,
-  StatusField,
-  ProjectsAndEnvironmentsFields,
   TenantAdminField,
-  RolesField,
+  RoleAssignmentsField,
 } from "./FormFields";
 import type { UserMutationData } from "@/types/admin/user";
 
@@ -59,6 +57,7 @@ export function UserForm({
       projects: [],
       environments: [],
       roles: [],
+      assignments: [],
       is_tenant_admin: false,
       ...initialData,
     },
@@ -115,10 +114,8 @@ export function UserForm({
               <EmailField form={form} />
               {isEditMode && (
                 <>
-                  <StatusField form={form} />
                   <TenantAdminField form={form} />
-                  <RolesField form={form} />
-                  <ProjectsAndEnvironmentsFields form={form} />
+                  <RoleAssignmentsField form={form} />
                 </>
               )}
             </div>

--- a/src/features/admin/users/components/userFormSchema.ts
+++ b/src/features/admin/users/components/userFormSchema.ts
@@ -18,6 +18,15 @@ export const userEditSchema = z.object({
   projects: z.array(z.string()).optional(),
   environments: z.array(z.string()).optional(),
   roles: z.array(z.string()).optional(),
+  assignments: z
+    .array(
+      z.object({
+        project: z.string().min(1, 'Project is required'),
+        environment: z.string().min(1, 'Environment is required'),
+        role: z.string().min(1, 'Role is required'),
+      })
+    )
+    .optional(),
   is_tenant_admin: z.boolean().optional(),
   username: z.string().optional(),
 });
@@ -31,6 +40,12 @@ export type UserCreateValues = z.infer<typeof userCreateSchema>
 export interface SelectOption {
   label: string
   value: string
+}
+
+export interface RoleAssignment {
+  project: string
+  environment: string
+  role: string
 }
 
 export const getProjectOptions = (projects: Project[]) => {

--- a/src/types/admin/user.d.ts
+++ b/src/types/admin/user.d.ts
@@ -64,6 +64,11 @@ export type UserUpdateData = {
   roles?: string[];
   projects?: string[];
   environments?: string[];
+  assignments?: {
+    project: string;
+    environment: string;
+    role: string;
+  }[];
   is_tenant_admin?: boolean;
 };
 


### PR DESCRIPTION
## Summary
- allow assigning roles per project/environment
- simplify edit user layout
- update user types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687696b7c14083248b196f026e1aab27