### PR TITLE
Add role assignment in AddUser flow

### DIFF
--- a/src/features/admin/users/components/FormFields.tsx
+++ b/src/features/admin/users/components/FormFields.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { MultiSelect } from "./MultiSelect"
 import { getProjectOptions, getEnvironmentOptions } from "./userFormSchema"
+import { AVAILABLE_ROLES } from "@/types/admin/roles"
 import { Button } from "@/components/ui/button"
 import { useFieldArray } from "react-hook-form"
 import {
@@ -134,11 +135,13 @@ export const TenantAdminField = ({ form }: { form: any }) => (
 )
 
 export const RolesField = ({ form }: { form: any }) => {
-  const roleOptions = [
-    { label: 'Designer', value: 'designer' },
-    { label: 'Ops User', value: 'ops_user' },
-    { label: 'Admin', value: 'admin' },
-  ]
+  const roleOptions = AVAILABLE_ROLES.map(role => ({
+    label: role
+      .split('_')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' '),
+    value: role
+  }))
 
   return (
     <MultiSelect
@@ -156,11 +159,13 @@ export const RoleAssignmentsField = ({ form }: { form: any }) => {
   const environments = useAppSelector((state) => state.users.environments)
   const projectOptions = getProjectOptions(projects)
   const environmentOptions = getEnvironmentOptions(environments)
-  const roleOptions = [
-    { label: 'Designer', value: 'designer' },
-    { label: 'Ops User', value: 'ops_user' },
-    { label: 'Admin', value: 'admin' },
-  ]
+  const roleOptions = AVAILABLE_ROLES.map(role => ({
+    label: role
+      .split('_')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' '),
+    value: role
+  }))
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: 'assignments'

--- a/src/features/admin/users/components/UserForm.tsx
+++ b/src/features/admin/users/components/UserForm.tsx
@@ -42,6 +42,8 @@ export function UserForm({
       first_name: '',
       last_name: '',
       email: '',
+      assignments: [],
+      is_tenant_admin: false,
       ...initialData,
     },
   });
@@ -112,12 +114,8 @@ export function UserForm({
             <div className="space-y-6">
               <NameFields form={form} disabled={isEditMode} />
               <EmailField form={form} />
-              {isEditMode && (
-                <>
-                  <TenantAdminField form={form} />
-                  <RoleAssignmentsField form={form} />
-                </>
-              )}
+              <TenantAdminField form={form} />
+              <RoleAssignmentsField form={form} />
             </div>
 
             <div className="flex flex-col items-center pt-6 border-t">

--- a/src/features/admin/users/components/userFormSchema.ts
+++ b/src/features/admin/users/components/userFormSchema.ts
@@ -7,6 +7,16 @@ export const userCreateSchema = z.object({
   first_name: z.string().min(1, 'First name is required'),
   last_name: z.string().min(1, 'Last name is required'),
   email: z.string().email('Invalid email address'),
+  assignments: z
+    .array(
+      z.object({
+        project: z.string().min(1, 'Project is required'),
+        environment: z.string().min(1, 'Environment is required'),
+        role: z.string().min(1, 'Role is required'),
+      })
+    )
+    .optional(),
+  is_tenant_admin: z.boolean().optional(),
 });
 
 // Edit mode schema - all fields

--- a/src/pages/admin/user/UserAdd.tsx
+++ b/src/pages/admin/user/UserAdd.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { withPageErrorBoundary} from '@/components/withPageErrorBoundary';
 import { AddUser } from '@/features/admin/users/AddUser';
-import { fetchProjects } from '@/store/slices/admin/usersSlice';
+import { fetchProjects, fetchEnvironments } from '@/store/slices/admin/usersSlice';
 import { useAppDispatch } from '@/hooks/useRedux';
 
 const UserAdd = () => {
@@ -9,6 +9,7 @@ const UserAdd = () => {
 
   useEffect(() => {
     dispatch(fetchProjects());
+    dispatch(fetchEnvironments());
   }, [dispatch]);
 
   return (

--- a/src/types/admin/roles.ts
+++ b/src/types/admin/roles.ts
@@ -1,0 +1,16 @@
+export const AVAILABLE_ROLES = ["designer", "ops_user", "viewer", "qa"] as const;
+export type AppRoles = (typeof AVAILABLE_ROLES)[number];
+
+export type RoleType<T extends string = AppRoles> = {
+  [K in T]?: boolean;
+};
+
+export type ScopedRoles<T extends string = AppRoles> = {
+  [name: string]: RoleType<T>;
+};
+
+export interface UserRole<T extends string = AppRoles> {
+  tenant_admin: boolean;
+  projects: ScopedRoles<T>;
+  environments: ScopedRoles<T>;
+}


### PR DESCRIPTION
## Summary
- allow setting user permissions during creation
- fetch environment list on the Add User page
- map role options from a single constant
- define generic role type utilities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68784d10dd0c832497ce995486cd9c68