### PR TITLE
Fix admin role detection and form

### DIFF
--- a/src/features/admin/users/AddUser.tsx
+++ b/src/features/admin/users/AddUser.tsx
@@ -15,7 +15,11 @@ export function AddUser() {
   const onSubmit = async (data: UserCreateValues) => {
     try {
       setError(null);
-      await handleCreateUser(data as unknown as UserCreateData);
+      const payload = { ...data } as UserCreateData;
+      if (payload.is_tenant_admin) {
+        delete (payload as any).assignments;
+      }
+      await handleCreateUser(payload);
       navigate(ROUTES.ADMIN.USERS.INDEX);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create user');

--- a/src/features/admin/users/EditUser.tsx
+++ b/src/features/admin/users/EditUser.tsx
@@ -8,6 +8,7 @@ import { useUserUpdateMutation } from "./hooks/useUserUpdateMutation";
 import { UserPageLayout } from "./components/UserPageLayout";
 import type { UserFormValues } from "./components/userFormSchema";
 import type { UserUpdateData } from "@/types/admin/user";
+import type { Role } from "@/types/admin/roles";
 
 export function EditUser() {
   const navigate = useNavigate();
@@ -21,7 +22,11 @@ export function EditUser() {
 
     try {
       setError(null);
-      await handleUpdateUser(id, data as unknown as UserUpdateData);
+      const payload = { ...data } as UserUpdateData;
+      if (payload.is_tenant_admin) {
+        delete (payload as any).assignments;
+      }
+      await handleUpdateUser(id, payload);
       navigate(ROUTES.ADMIN.USERS.INDEX);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update user');
@@ -37,6 +42,10 @@ export function EditUser() {
   }
 
   // Transform user data for form initialization
+  const isTenantAdmin = (user.roles as Role[] | undefined)?.some(
+    (r) => r.module_name === 'tenant_admin' && r.module_type === 'admin'
+  ) ?? false
+
   const formInitialData: UserFormValues = {
     first_name: user.firstName,
     last_name: user.lastName,
@@ -44,11 +53,7 @@ export function EditUser() {
     username: user.username,
     enabled: user.enabled,
     emailVerified: user.emailVerified,
-    is_tenant_admin: user.access?.manage && 
-                     user.access?.manageGroupMembership && 
-                     user.access?.view && 
-                     user.access?.mapRoles && 
-                     user.access?.impersonate,
+    is_tenant_admin: isTenantAdmin,
     // Add any role assignments if available
     assignments: [], // Populate from user.assignments if available
   };

--- a/src/features/admin/users/components/FormFields.tsx
+++ b/src/features/admin/users/components/FormFields.tsx
@@ -23,13 +23,16 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { useAppSelector } from "@/hooks/useRedux"
 import type { User } from "@/types/admin/user"
+import type { Role } from "@/types/admin/roles"
 
-// Helper function to check if user has admin access
-const isUserAdmin = (user?: User): boolean => {
-  if (!user?.access) return false;
-  const { manageGroupMembership, view, mapRoles, impersonate, manage } = user.access;
-  return manageGroupMembership && view && mapRoles && impersonate && manage;
-};
+// Helper function to check if user has admin access based on roles
+const isUserAdmin = (user?: User & { roles?: Role[] }): boolean => {
+  return (
+    user?.roles?.some(
+      (r) => r.module_name === 'tenant_admin' && r.module_type === 'admin'
+    ) ?? false
+  )
+}
 
 export const RequiredFormLabel = ({ children }: { children: React.ReactNode }) => (
   <FormLabel className="flex gap-1">

--- a/src/features/admin/users/components/UserForm.tsx
+++ b/src/features/admin/users/components/UserForm.tsx
@@ -77,7 +77,13 @@ export function UserForm<T extends BaseUserFields = AnyUserFormValues>({
   const handleSubmit = async (data: T) => {
     try {
       setFormState("submitting");
-      await onSubmit(data);
+      const payload: any = { ...data };
+      if (payload.is_tenant_admin) {
+        delete payload.assignments;
+        delete payload.project_assignments;
+        delete payload.environment_assignments;
+      }
+      await onSubmit(payload as T);
       setFormState("success");
     } catch (err) {
       setFormState("error");
@@ -231,7 +237,8 @@ export function UserForm<T extends BaseUserFields = AnyUserFormValues>({
           </Card>
 
           {/* Role Assignments Section */}
-          <Accordion type="single" collapsible className="w-full">
+          {!form.watch("is_tenant_admin" as Path<T>) && (
+            <Accordion type="single" collapsible className="w-full">
             <AccordionItem value="role-assignments" className="border rounded-lg border-l-4 border-l-green-500">
               <AccordionTrigger className="px-6 py-4 hover:no-underline">
                 <div className="flex items-center gap-2">
@@ -282,6 +289,7 @@ export function UserForm<T extends BaseUserFields = AnyUserFormValues>({
               </AccordionContent>
             </AccordionItem>
           </Accordion>
+          )}
 
           <Separator />
 

--- a/src/types/admin/user.d.ts
+++ b/src/types/admin/user.d.ts
@@ -1,4 +1,4 @@
-import type { AppRoles } from "./roles";
+import type { AppRoles, Role } from "./roles";
 
 export interface Pagination {
   total: number;
@@ -30,6 +30,7 @@ export interface User extends BaseUser {
     impersonate: boolean;
     manage: boolean;
   };
+  roles?: Role[];
 }
 
 export interface UsersPaginatedResponse extends Pagination {


### PR DESCRIPTION
## Summary
- detect admin role from `roles` array instead of `access`
- drop role assignments when user is tenant admin
- hide role assignment UI for admins
- add `roles` field to `User` type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e0085cef4832494b8238a854bcc81