### PR TITLE
feat: show streaming title in data explorer

### DIFF
--- a/current-implementation.md
+++ b/current-implementation.md
@@ -1,0 +1,24 @@
+# Data Explorer setup from `Home.tsx`
+
+1. **Page wrapper**
+   - `Home.tsx` renders only the chat message body and is wrapped by `HomeLayout` via the `withHomeLayout` HOC, keeping page logic thin and layout‑driven
+
+2. **Layout orchestration**
+   - `HomeLayout` manages chat state, suggestions, and a resizable right pane. When the chat context equals `action-explore-data`, the right pane widens and displays data‑exploration content, with recommendations fetched through `useRecommendation('explorer')`
+
+3. **Initiating exploration**
+   - Selecting “Explore Data” either from the actions list or the “+” menu sets the context to `action-explore-data` without immediately calling the backend
+   - Choosing a connection triggers `createConversation` to obtain a thread ID, while `ChatInput` later submits the user’s query to `processExploreQuery` when in explorer context
+
+4. **Chat service hand‑off**
+   - `ChatService.processExploreQuery` stores the query/connection and injects a clickable card (`explore-data-card`) into the chat. Clicking it calls `handleExploreCardClick`, which opens a `RightAsideComponent` of type `explore-data` and passes the query, connection, and thread ID
+
+5. **Right‑side rendering**
+   - `RightAsideComponent` switches on `componentId`; for `explore-data` it renders `ExploreDataComponent`, keeping the panel open until closed and relaying success messages as needed
+
+6. **Streaming analysis UI**
+   - `ExploreDataComponent` streams results via `useConversation.streamConversation`, parsing SSE chunks (`MetaStarted`, `Identify`, `SQL`, `TABLE`, `EXPLANATION`, `MetaCompleted`) to update state and display progress with `StreamingStepIndicator`, final metrics, tables, SQL, and Plotly‑based charts in `OverviewTab`
+
+7. **Chat message interaction**
+   - `ChatMessages` routes card clicks (such as the exploration card) through `chatService.handleCardClick`, ensuring the correct side panel opens when the user interacts with chat UI components
+

--- a/src/components/chat/RightAsideComponent.tsx
+++ b/src/components/chat/RightAsideComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X, FileText, GitBranch, Table as TableIcon, Eye, Code2 } from 'lucide-react';
+import { X, FileText, GitBranch, Table as TableIcon, Eye, Code2, Loader2 } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '@/hooks/useRedux';
 import { setRightComponent, addMessage, openChatBottomDrawer, closeChatBottomDrawer, setChatBottomDrawerHeight } from '@/store/slices/chat/chatSlice';
 import { getChatService } from '@/services/chatService';
@@ -47,6 +47,13 @@ export const RightAsideComponent: React.FC = () => {
 
   // sync SidebarContext open/close with Redux bottom drawer so DataPipelineCanvasNew controls still work if needed
   const { isBottomDrawerOpen, openBottomDrawer, closeBottomDrawer, updateBottomDrawerHeight } = useSidebar();
+
+  const [exploreTitle, setExploreTitle] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    if (rightComponent?.componentId !== 'explore-data') {
+      setExploreTitle(null);
+    }
+  }, [rightComponent?.componentId]);
   
   React.useEffect(() => {
     if (bottomDrawer.isOpen && !isBottomDrawerOpen) openBottomDrawer();
@@ -169,10 +176,11 @@ export const RightAsideComponent: React.FC = () => {
         );
       case 'explore-data':
         return (
-          <ExploreDataComponent 
+          <ExploreDataComponent
             query={(rightComponent as any).extra?.query}
             connection={(rightComponent as any).extra?.connection}
             threadId={(rightComponent as any).extra?.threadId}
+            onTitleChange={setExploreTitle}
           />
         );
       default:
@@ -202,8 +210,13 @@ export const RightAsideComponent: React.FC = () => {
           className="flex p-1 flex-row items-center justify-between space-y-0 bg-gradient-to-r from-primary/5 via-transparent to-transparent"
         >
           <div className="flex items-center gap-3 min-w-0 flex-1">
-            <CardTitle className="text-base font-medium truncate min-w-0" title={rightComponent.title}>
-              {rightComponent.title}
+            <CardTitle
+              className="text-base font-medium truncate min-w-0"
+              title={rightComponent.componentId === 'explore-data' ? exploreTitle ?? undefined : rightComponent.title}
+            >
+              {rightComponent.componentId === 'explore-data'
+                ? (exploreTitle ? exploreTitle : <Loader2 className="h-4 w-4 animate-spin" />)
+                : rightComponent.title}
             </CardTitle>
             {/* Segmented toggle (visible when extra.toggles is provided) */}
             {Array.isArray((rightComponent as any).extra?.toggles) && (

--- a/src/components/chat/features/AnalysisMetrics.tsx
+++ b/src/components/chat/features/AnalysisMetrics.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import type { IdentifyEvent, MetaCompletedEvent } from '@/types/streaming';
 
 interface AnalysisMetricsProps {
-  identify?: IdentifyEvent['content'];
+  identify?: IdentifyEvent['content'][];
   duration_ms?: MetaCompletedEvent['data']['duration_ms'];
   results_summary?: MetaCompletedEvent['data']['results_summary'];
 }
@@ -15,16 +15,18 @@ export const AnalysisMetrics: React.FC<AnalysisMetricsProps> = ({
 }) => {
   const duration = typeof duration_ms === 'number' ? `${(duration_ms / 1000).toFixed(1)}s` : undefined;
   const tablesGenerated = results_summary?.tables_generated;
+  const identifyLabel = identify?.join(', ');
+  const identifyPlural = (identify?.length || 0) > 1;
 
-  if (!identify && !duration && !tablesGenerated) {
+  if (!identifyLabel && !duration && !tablesGenerated) {
     return null;
   }
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-2">
       <div className="text-left text-sm text-muted-foreground">
-        {identify && (
-          <>Identified source: <span className="font-medium text-foreground">{identify}</span></>
+        {identifyLabel && (
+          <>Identified {identifyPlural ? 'sources' : 'source'}: <span className="font-medium text-foreground">{identifyLabel}</span></>
         )}
       </div>
       <div className="flex flex-wrap gap-2">

--- a/src/components/chat/features/StreamingContent.tsx
+++ b/src/components/chat/features/StreamingContent.tsx
@@ -7,7 +7,7 @@ import type { TableEvent, SqlEvent, IdentifyEvent, ExplanationEvent } from '@/ty
 
 interface StreamingContentProps {
   currentStep?: StreamingStep;
-  identify?: IdentifyEvent['content'];
+  identify?: IdentifyEvent['content'][];
   sql?: SqlEvent['content'];
   table?: TableEvent['content'];
   explanation?: ExplanationEvent['content'];
@@ -22,6 +22,9 @@ export const StreamingContent: React.FC<StreamingContentProps> = ({
   explanation,
   onCopy
 }) => {
+  const identifyLabel = identify?.join(', ');
+  const identifyPlural = (identify?.length || 0) > 1;
+
   if (!currentStep) {
     return (
       <div className="flex flex-col items-center space-y-4 py-8">
@@ -48,9 +51,9 @@ export const StreamingContent: React.FC<StreamingContentProps> = ({
               <Search className="w-8 h-8 text-green-500" />
               <p className="text-sm text-muted-foreground">Identifying data sources...</p>
             </div>
-            {identify && (
+            {identifyLabel && (
               <div className="text-sm text-muted-foreground animate-in fade-in duration-300">
-                Identified source: <span className="font-medium text-foreground">{identify}</span>
+                Identified {identifyPlural ? 'sources' : 'source'}: <span className="font-medium text-foreground">{identifyLabel}</span>
               </div>
             )}
           </div>
@@ -63,9 +66,9 @@ export const StreamingContent: React.FC<StreamingContentProps> = ({
               <Code className="w-8 h-8 text-yellow-500" />
               <p className="text-sm text-muted-foreground">Generating SQL query...</p>
             </div>
-            {identify && (
+            {identifyLabel && (
               <div className="text-sm text-muted-foreground">
-                Source: <span className="font-medium text-foreground">{identify}</span>
+                Source{identifyPlural ? 's' : ''}: <span className="font-medium text-foreground">{identifyLabel}</span>
               </div>
             )}
             {sql && (
@@ -83,9 +86,9 @@ export const StreamingContent: React.FC<StreamingContentProps> = ({
               <Database className="w-8 h-8 text-purple-500" />
               <p className="text-sm text-muted-foreground">Executing query and fetching data...</p>
             </div>
-            {identify && (
+            {identifyLabel && (
               <div className="text-sm text-muted-foreground">
-                Source: <span className="font-medium text-foreground">{identify}</span>
+                Source{identifyPlural ? 's' : ''}: <span className="font-medium text-foreground">{identifyLabel}</span>
               </div>
             )}
             {sql && <SqlBlock title="SQL Query" sql={sql} canCopy={!!onCopy} />}
@@ -105,9 +108,9 @@ export const StreamingContent: React.FC<StreamingContentProps> = ({
               <FileText className="w-8 h-8 text-orange-500" />
               <p className="text-sm text-muted-foreground">Generating explanation...</p>
             </div>
-            {identify && (
+            {identifyLabel && (
               <div className="text-sm text-muted-foreground">
-                Source: <span className="font-medium text-foreground">{identify}</span>
+                Source{identifyPlural ? 's' : ''}: <span className="font-medium text-foreground">{identifyLabel}</span>
               </div>
             )}
             {sql && <SqlBlock title="SQL Query" sql={sql} canCopy={!!onCopy} />}


### PR DESCRIPTION
## Summary
- propagate MetaStarted title from ExploreDataComponent
- display stream title in right-side explorer header with spinner while loading
- collect multiple IDENTIFY events and show all sources in explorer
- document data explorer setup in current-implementation.md

## Testing
- `npm install --no-save playwright @eslint/js` *(fails: 403 Forbidden - access to @bh-ai/schemas denied)*
- `npm test` *(fails: playwright: not found)*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e06964588324aa7e7ba6c0c32cc3